### PR TITLE
Allow args w/ spaces in generated AppRun

### DIFF
--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -130,7 +130,7 @@ for onefile creation to work on Linux."""
         output_file.write(
             """\
 #!/bin/bash
-exec -a $ARGV0 $APPDIR/%s $@"""
+exec -a $ARGV0 $APPDIR/%s \"$@\""""
             % os.path.basename(binary_filename)
         )
 


### PR DESCRIPTION
Quotes the args on the exec statement in AppRun allowing for args with spaces such as filenames

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
